### PR TITLE
Use HashSet for default user role assignment

### DIFF
--- a/src/main/java/com/example/bestellsystem/service/UserService.java
+++ b/src/main/java/com/example/bestellsystem/service/UserService.java
@@ -5,7 +5,8 @@ import com.example.bestellsystem.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Set;
+import java.util.HashSet;
+import java.util.Collections;
 
 @Service
 public class UserService {
@@ -24,7 +25,7 @@ public class UserService {
         }
 
         user.setPassword(passwordEncoder.encode(user.getPassword()));
-        user.setRoles(Set.of("USER")); // Default role
+        user.setRoles(new HashSet<>(Collections.singleton("USER"))); // Default role
         userRepository.save(user);
     }
 }


### PR DESCRIPTION
## Summary
- Replace Set.of with new HashSet<>(Collections.singleton("USER")) when assigning default role
- Add imports for HashSet and Collections

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c06a9d9fd483289514a27c8c84186e