### PR TITLE
Use requestMatchers in security config

### DIFF
--- a/src/main/java/com/example/bestellsystem/config/SecurityConfig.java
+++ b/src/main/java/com/example/bestellsystem/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(authz -> authz
-                .antMatchers("/", "/register", "/css/**", "/js/**").permitAll()
+                .requestMatchers("/", "/register", "/css/**", "/js/**").permitAll()
                 .anyRequest().authenticated()
             )
             .formLogin(form -> form


### PR DESCRIPTION
## Summary
- replace deprecated antMatchers with requestMatchers in SecurityConfig

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c06ac94d588328b23c796ad00def45