### PR TITLE
Handle missing security principal in OrderService

### DIFF
--- a/src/main/java/com/example/bestellsystem/service/OrderService.java
+++ b/src/main/java/com/example/bestellsystem/service/OrderService.java
@@ -32,8 +32,9 @@ public class OrderService {
     }
 
     private User getUser(Principal principal) {
-        // The principal should always be valid in a secured context.
-        // Throwing an exception here is appropriate if the user is not found.
+        if (principal == null) {
+            throw new IllegalStateException("No authenticated principal found");
+        }
         return userRepository.findByUsername(principal.getName())
                 .orElseThrow(() -> new IllegalArgumentException("User not found in security principal"));
     }

--- a/src/test/java/com/example/bestellsystem/service/OrderServiceTest.java
+++ b/src/test/java/com/example/bestellsystem/service/OrderServiceTest.java
@@ -14,6 +14,7 @@ import java.security.Principal;
 import java.util.Optional;
 
 import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class OrderServiceTest {
@@ -65,5 +66,10 @@ class OrderServiceTest {
         verify(userRepository).findByUsername(username);
         verify(orderRepository).save(order);
         assert(order.getUser().equals(user));
+    }
+
+    @Test
+    void findOrdersForCurrentUser_shouldThrowIfPrincipalIsNull() {
+        assertThrows(IllegalStateException.class, () -> orderService.findOrdersForCurrentUser(null));
     }
 }


### PR DESCRIPTION
## Summary
- Throw `IllegalStateException` when no authenticated `Principal` is present.
- Cover null principal scenario in `OrderServiceTest`.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c06ac9c9348328ae3dfe7411dfee79