### PR TITLE
Switch to Role enum for user authorization

### DIFF
--- a/src/main/java/com/example/bestellsystem/model/Role.java
+++ b/src/main/java/com/example/bestellsystem/model/Role.java
@@ -1,0 +1,6 @@
+package com.example.bestellsystem.model;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/example/bestellsystem/model/User.java
+++ b/src/main/java/com/example/bestellsystem/model/User.java
@@ -1,18 +1,22 @@
 package com.example.bestellsystem.model;
 
-import javax.persistence.Entity;
 import javax.persistence.CollectionTable;
+import javax.persistence.Column;
 import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Column;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -33,7 +37,8 @@ public class User {
 
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
-    private java.util.Set<String> roles = new java.util.HashSet<>();
+    @Enumerated(EnumType.STRING)
+    private Set<Role> roles = new HashSet<>();
 
     public Long getId() {
         return id;
@@ -59,11 +64,11 @@ public class User {
         this.password = password;
     }
 
-    public java.util.Set<String> getRoles() {
+    public Set<Role> getRoles() {
         return roles;
     }
 
-    public void setRoles(java.util.Set<String> roles) {
+    public void setRoles(Set<Role> roles) {
         this.roles = roles;
     }
 

--- a/src/main/java/com/example/bestellsystem/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/bestellsystem/service/UserDetailsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.bestellsystem.service;
 
+import com.example.bestellsystem.model.Role;
 import com.example.bestellsystem.model.User;
 import com.example.bestellsystem.repository.UserRepository;
 import org.springframework.security.core.GrantedAuthority;
@@ -10,6 +11,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,9 +33,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
                 getAuthorities(user.getRoles()));
     }
 
-    private Collection<GrantedAuthority> getAuthorities(java.util.Set<String> roles) {
+    private Collection<GrantedAuthority> getAuthorities(Set<Role> roles) {
         return roles.stream()
-                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.trim()))
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/bestellsystem/service/UserService.java
+++ b/src/main/java/com/example/bestellsystem/service/UserService.java
@@ -1,12 +1,12 @@
 package com.example.bestellsystem.service;
 
+import com.example.bestellsystem.model.Role;
 import com.example.bestellsystem.model.User;
 import com.example.bestellsystem.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
-import java.util.Collections;
+import java.util.EnumSet;
 
 @Service
 public class UserService {
@@ -25,7 +25,7 @@ public class UserService {
         }
 
         user.setPassword(passwordEncoder.encode(user.getPassword()));
-        user.setRoles(new HashSet<>(Collections.singleton("USER"))); // Default role
+        user.setRoles(EnumSet.of(Role.USER)); // Default role
         userRepository.save(user);
     }
 }

--- a/src/test/java/com/example/bestellsystem/OrderControllerTests.java
+++ b/src/test/java/com/example/bestellsystem/OrderControllerTests.java
@@ -1,5 +1,6 @@
 package com.example.bestellsystem;
 
+import com.example.bestellsystem.model.Role;
 import com.example.bestellsystem.model.User;
 import com.example.bestellsystem.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +12,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumSet;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -41,6 +44,7 @@ class OrderControllerTests {
         User testUser = new User();
         testUser.setUsername("testuser");
         testUser.setPassword("password");
+        testUser.setRoles(EnumSet.of(Role.USER));
         userRepository.save(testUser);
 
         mockMvc.perform(get("/orders"))
@@ -55,6 +59,7 @@ class OrderControllerTests {
         User testUser = new User();
         testUser.setUsername("testuser");
         testUser.setPassword("password");
+        testUser.setRoles(EnumSet.of(Role.USER));
         userRepository.save(testUser);
 
         mockMvc.perform(post("/orders")

--- a/src/test/java/com/example/bestellsystem/WebControllerTests.java
+++ b/src/test/java/com/example/bestellsystem/WebControllerTests.java
@@ -1,5 +1,6 @@
 package com.example.bestellsystem;
 
+import com.example.bestellsystem.model.Role;
 import com.example.bestellsystem.model.User;
 import com.example.bestellsystem.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumSet;
 
 import java.util.Optional;
 
@@ -93,6 +96,7 @@ class WebControllerTests {
         User existingUser = new User();
         existingUser.setUsername("existinguser");
         existingUser.setPassword("password123");
+        existingUser.setRoles(EnumSet.of(Role.USER));
         userRepository.save(existingUser);
 
         mockMvc.perform(post("/register")


### PR DESCRIPTION
## Summary
- add `Role` enum defining `USER` and `ADMIN`
- store roles as `Set<Role>` in `User` and default to `EnumSet.of(Role.USER)` during registration
- map `Role` to `SimpleGrantedAuthority` in `UserDetailsServiceImpl`
- adjust tests to create users with enum-based roles

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c070fe0d5883288a7aaa90d1e5aeb1