### PR TITLE
Add tests for UserDetailsServiceImpl

### DIFF
--- a/src/test/java/com/example/bestellsystem/service/UserDetailsServiceImplTest.java
+++ b/src/test/java/com/example/bestellsystem/service/UserDetailsServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.example.bestellsystem.service;
+
+import com.example.bestellsystem.model.User;
+import com.example.bestellsystem.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserDetailsServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    void loadUserByUsername_returnsUserDetails() {
+        // Arrange
+        String username = "testuser";
+        String encodedPassword = new BCryptPasswordEncoder().encode("password");
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(encodedPassword);
+        user.setRoles(new HashSet<>(Arrays.asList("USER", "ADMIN")));
+
+        when(userRepository.findByUsernameWithRoles(username)).thenReturn(Optional.of(user));
+
+        // Act
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+        // Assert
+        assertEquals(username, userDetails.getUsername());
+        assertEquals(encodedPassword, userDetails.getPassword());
+        assertTrue(userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_USER")));
+        assertTrue(userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN")));
+    }
+
+    @Test
+    void loadUserByUsername_throwsException_whenUserNotFound() {
+        // Arrange
+        String username = "unknown";
+        when(userRepository.findByUsernameWithRoles(username)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(UsernameNotFoundException.class, () -> userDetailsService.loadUserByUsername(username));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for `UserDetailsServiceImpl` to verify returned username, encoded password, and authorities
- add test ensuring `loadUserByUsername` throws `UsernameNotFoundException` when user is missing

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c071005e7c8328aaaf83c99ccff8c8