### PR TITLE
Add global exception handling

### DIFF
--- a/src/main/java/com/example/bestellsystem/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/bestellsystem/controller/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.example.bestellsystem.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body("Invalid request: " + ex.getMessage());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleIllegalState(IllegalStateException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("Unexpected state: " + ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGeneric(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("An error occurred: " + ex.getMessage());
+    }
+}

--- a/src/test/java/com/example/bestellsystem/GlobalExceptionHandlerTests.java
+++ b/src/test/java/com/example/bestellsystem/GlobalExceptionHandlerTests.java
@@ -1,0 +1,52 @@
+package com.example.bestellsystem;
+
+import com.example.bestellsystem.controller.GlobalExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GlobalExceptionHandlerTests.TestExceptionController.class)
+@Import(GlobalExceptionHandler.class)
+class GlobalExceptionHandlerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RestController
+    static class TestExceptionController {
+        @GetMapping("/test/illegal-argument")
+        public void throwIllegalArgument() {
+            throw new IllegalArgumentException("bad argument");
+        }
+
+        @GetMapping("/test/illegal-state")
+        public void throwIllegalState() {
+            throw new IllegalStateException("bad state");
+        }
+    }
+
+    @Test
+    @WithMockUser
+    void handlesIllegalArgument() throws Exception {
+        mockMvc.perform(get("/test/illegal-argument"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Invalid request: bad argument"));
+    }
+
+    @Test
+    @WithMockUser
+    void handlesIllegalState() throws Exception {
+        mockMvc.perform(get("/test/illegal-state"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().string("Unexpected state: bad state"));
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `GlobalExceptionHandler` with controller advice and specific exception handlers for `IllegalArgumentException`, `IllegalStateException`, and general exceptions.
- Add `GlobalExceptionHandlerTests` to verify exception-to-response mappings using `MockMvc`.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c071020af08328856ef881b443bc4c